### PR TITLE
feat: Use uv instead of pip-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ channels:
 dependencies:
   - python=3.11
   - pip:
-    - pip-tools
+    - uv
 ```
 
 3. Run `make help` to see available targets:

--- a/example/environment.yml
+++ b/example/environment.yml
@@ -3,4 +3,4 @@ channels:
 dependencies:
   - python=3.11.4
   - pip:
-    - pip-tools
+    - uv

--- a/micromamba.mk
+++ b/micromamba.mk
@@ -18,16 +18,16 @@ activate: ## Open a new shell with the activated environment
 
 .PHONY: deps
 deps: env ## Sync dependencies in the virtual environment
-	uv pip sync requirements-dev.txt
+	@$(VENV)/bin/uv pip sync requirements-dev.txt
 	@$(VENV)/bin/pre-commit install >/dev/null
 
 .PHONY: lockdeps
 lockdeps: env ## Update or generate dependency lock files
-	uv pip compile setup.cfg -o requirements.txt $(args)
+	@$(VENV)/bin/uv pip compile setup.cfg -o requirements.txt $(args)
 	@for extra in $$($(PYTHON) -c \
 		'from setuptools.config.setupcfg import read_configuration as c; \
 		print(*c("setup.cfg")["options"]["extras_require"])'); do \
-			uv pip compile setup.cfg \
+			$(VENV)/bin/uv pip compile setup.cfg \
 			-o requirements-$$extra.txt --extra $$extra $(args); \
 	done
 

--- a/micromamba.mk
+++ b/micromamba.mk
@@ -18,7 +18,7 @@ activate: ## Open a new shell with the activated environment
 
 .PHONY: deps
 deps: env ## Sync dependencies in the virtual environment
-	@$(VENV)/bin/uv pip sync requirements-dev.txt
+	@CONDA_PREFIX=$(VENV) $(VENV)/bin/uv pip sync requirements-dev.txt
 	@$(VENV)/bin/pre-commit install >/dev/null
 
 .PHONY: lockdeps

--- a/micromamba.mk
+++ b/micromamba.mk
@@ -18,17 +18,17 @@ activate: ## Open a new shell with the activated environment
 
 .PHONY: deps
 deps: env ## Sync dependencies in the virtual environment
-	@$(VENV)/bin/pip-sync requirements-dev.txt
+	uv pip sync requirements-dev.txt
 	@$(VENV)/bin/pre-commit install >/dev/null
 
 .PHONY: lockdeps
 lockdeps: env ## Update or generate dependency lock files
-	@$(VENV)/bin/pip-compile setup.cfg --resolver backtracking -o requirements.txt -v $(args)
+	uv pip compile setup.cfg -o requirements.txt $(args)
 	@for extra in $$($(PYTHON) -c \
 		'from setuptools.config.setupcfg import read_configuration as c; \
 		print(*c("setup.cfg")["options"]["extras_require"])'); do \
-			$(VENV)/bin/pip-compile setup.cfg --resolver backtracking \
-			-o requirements-$$extra.txt --extra $$extra -v $(args); \
+			uv pip compile setup.cfg \
+			-o requirements-$$extra.txt --extra $$extra $(args); \
 	done
 
 .PHONY: check


### PR DESCRIPTION
uv is faster, and has managed to solve my dependencies more consistently.

* -v is not necessary, as uv's default log level is not as silent as pip-tools
* --resolver backtracking is not necessary, as uv always backtracks

- [x] add uv as a dependency in readme
- [x] install uv when creating the env
- [x] test example project